### PR TITLE
Raft Leader Election

### DIFF
--- a/6.824/src/labrpc/labrpc.go
+++ b/6.824/src/labrpc/labrpc.go
@@ -49,15 +49,18 @@ package labrpc
 //   pass svc to srv.AddService()
 //
 
-import "6.824/labgob"
-import "bytes"
-import "reflect"
-import "sync"
-import "log"
-import "strings"
-import "math/rand"
-import "time"
-import "sync/atomic"
+import (
+	"bytes"
+	"log"
+	"math/rand"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	labgob "github.com/mit-distributed-systems/6.824/src/labgob"
+)
 
 type reqMsg struct {
 	endname  interface{} // name of sending ClientEnd

--- a/6.824/src/raft/config.go
+++ b/6.824/src/raft/config.go
@@ -8,19 +8,23 @@ package raft
 // test with the original before submitting.
 //
 
-import "6.824/labgob"
-import "6.824/labrpc"
-import "bytes"
-import "log"
-import "sync"
-import "testing"
-import "runtime"
-import "math/rand"
-import crand "crypto/rand"
-import "math/big"
-import "encoding/base64"
-import "time"
-import "fmt"
+import (
+	"bytes"
+	"log"
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+
+	labgob "github.com/mit-distributed-systems/6.824/src/labgob"
+	labrpc "github.com/mit-distributed-systems/6.824/src/labrpc"
+
+	crand "crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"time"
+)
 
 func randstring(n int) string {
 	b := make([]byte, 2*n)

--- a/6.824/src/raft/raft.go
+++ b/6.824/src/raft/raft.go
@@ -358,6 +358,17 @@ func (rf *Raft) ticker() {
 		// Your code here to check if a leader election should
 		// be started and to randomize sleeping time using
 		// time.Sleep().
+		rf.mu.Lock()
+		state := rf.state
+		rf.mu.Unlock()
+		switch state {
+		case Leader:
+			select {
+			case <-rf.stepDownCh:
+				// state should already be a follower
+			default:
+			}
+		}
 
 	}
 }

--- a/6.824/src/raft/raft.go
+++ b/6.824/src/raft/raft.go
@@ -382,6 +382,22 @@ func Make(peers []*labrpc.ClientEnd, me int,
 
 	// Your initialization code here (2A, 2B, 2C).
 
+	// persistent state on all servers
+	rf.currentTerm = 0
+	rf.votedFor = -1
+	rf.log = append(rf.log, LogEntry{Term: 0})
+
+	// volatile state on all servers
+	rf.commitIndex = 0
+	rf.lastApplied = 0
+
+	// auxillary
+	rf.state = Follower
+	rf.voteCount = 0
+	rf.applyCh = applyCh
+	rf.stepDownCh = make(chan bool)
+	rf.grantVoteCh = make(chan bool)
+
 	// initialize from state persisted before a crash
 	rf.readPersist(persister.ReadRaftState())
 

--- a/6.824/src/raft/raft.go
+++ b/6.824/src/raft/raft.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 
 	//	"6.824/labgob"
-	"6.824/labrpc"
+	labrpc "github.com/mit-distributed-systems/6.824/src/labrpc"
 )
 
 //

--- a/6.824/src/raft/test_test.go
+++ b/6.824/src/raft/test_test.go
@@ -8,12 +8,14 @@ package raft
 // test with the original before submitting.
 //
 
-import "testing"
-import "fmt"
-import "time"
-import "math/rand"
-import "sync/atomic"
-import "sync"
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
 // The tester generously allows solutions to complete elections in one second
 // (much more than the paper's range of timeouts).


### PR DESCRIPTION
This PR implements the Leader Election part of the RAFT consensus protocol by appropriate timer triggering a server to propose its Candidature and request for votes from other servers. 

If the conditions are met re: most updated Log and Term in the Candidate's State, then it is elected as a Leader otherwise it is converted to a Follower.